### PR TITLE
Add compatibility layer for importing urlparse

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,18 +1,27 @@
 #!/usr/bin/env python
+
+import sys
+
 from setuptools import setup, find_packages
 
 PACKAGES = find_packages(where='src')
 
 INSTALL_REQUIRES = [
-    'sqlalchemy', 'pandas', 'pymysql'
+    'sqlalchemy',
+    'pandas',
+    'pymysql',
+    'requests',
+    'click',
 ]
+
+if sys.version_info < (3,):
+    INSTALL_REQUIRES.append('configparser')
 
 ENTRY_POINTS = {
     'console_scripts': [
         'pyctd = pyctd.cli:main',
     ]
 }
-
 
 setup(
     name="pyctd",

--- a/src/pyctd/manager/database.py
+++ b/src/pyctd/manager/database.py
@@ -12,7 +12,7 @@ from ..constants import PYCTD_DATA_DIR, PYCTD_DIR
 
 import os
 import re
-from urllib.parse import urlparse
+from requests.compat import urlparse
 from configparser import RawConfigParser
 from sqlalchemy import create_engine, inspect
 from sqlalchemy.orm import sessionmaker, scoped_session


### PR DESCRIPTION
Since urllib got renamed and cut up for python3, the requests library has a module called `requests.compat` that wraps up all the backwards compatibility